### PR TITLE
Proposed fix for a couple of memory leaks

### DIFF
--- a/src/t3d/t3d.c
+++ b/src/t3d/t3d.c
@@ -69,6 +69,12 @@ void t3d_destroy(void)
 {
   rspq_overlay_unregister(T3D_RSP_ID);
   T3D_RSP_ID = 0;
+
+  if(matrixStack)
+  {
+    free_uncached(matrixStack);
+    matrixStack = NULL;
+  }
 }
 
 void t3d_screen_clear_color(color_t color) {

--- a/tools/gltf_importer/Makefile
+++ b/tools/gltf_importer/Makefile
@@ -1,6 +1,7 @@
 CXXFLAGS += -O3 -std=c++20
 OBJDIR = build
 SRCDIR = src
+LINKFLAGS += -Wl,-Bstatic
 
 OBJ = build/parser.o build/main.o build/lib/lodepng.o \
 	build/parser/materialParser.o build/parser/boneParser.o build/parser/nodeParser.o \

--- a/tools/gltf_importer/Makefile
+++ b/tools/gltf_importer/Makefile
@@ -1,7 +1,6 @@
 CXXFLAGS += -O3 -std=c++20
 OBJDIR = build
 SRCDIR = src
-LINKFLAGS += -Wl,-Bstatic
 
 OBJ = build/parser.o build/main.o build/lib/lodepng.o \
 	build/parser/materialParser.o build/parser/boneParser.o build/parser/nodeParser.o \


### PR DESCRIPTION
- Fixed memory leak when t3d_destroy() is called
- Fixed memory leak in t3d_model_free(), since cache was not maintained with texture_cache_free()
- Added texture_cache_free_mem() which is called from t3d_model_free() if textures were removed from cache. This has the upkeep cost, but if not done here it should be done in t3d_destroy() or otherwise the cache stays in RAM.

Thanks for your awesome work!