### PR TITLE
Add a gitattributes file to set bash script line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+# These are all bash scripts and should use lf
+*.sh text eol=lf


### PR DESCRIPTION
They don't work on Windows with [libdragon-docker](https://github.com/anacierdem/libdragon-docker) out of the box without this change. These are bash scripts and there shouldn't be a need for CRLF anyways.