### PR TITLE
Add support for "make install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ include $(N64_INST)/include/n64.mk
 src := $(SOURCE_DIR)/t3d.c $(SOURCE_DIR)/t3dmath.c $(SOURCE_DIR)/t3dmodel.c \
 	$(SOURCE_DIR)/t3ddebug.c $(SOURCE_DIR)/t3dskeleton.c $(SOURCE_DIR)/t3danim.c \
 	$(SOURCE_DIR)/rsp/rsp_tiny3d.S
+inc := $(SOURCE_DIR)/t3d.h $(SOURCE_DIR)/t3dmath.h $(SOURCE_DIR)/t3dmodel.h \
+	$(SOURCE_DIR)/t3ddebug.h $(SOURCE_DIR)/t3dskeleton.h $(SOURCE_DIR)/t3danim.h
 
 # N64_CFLAGS += -std=gnu2x -DNDEBUG
 N64_CFLAGS += -std=gnu2x -Os -Isrc \
@@ -28,13 +30,13 @@ OBJ = $(BUILD_DIR)/t3dmath.o $(BUILD_DIR)/t3d.o \
 	$(BUILD_DIR)/t3dmodel.o $(BUILD_DIR)/t3ddebug.o $(BUILD_DIR)/t3dskeleton.o $(BUILD_DIR)/t3danim.o \
 	$(BUILD_DIR)/rsp/rsp_tiny3d.o $(BUILD_DIR)/rsp/rsp_tiny3d_clipping.o
 
-all: $(BUILD_DIR)/t3d.a
+all: $(BUILD_DIR)/libt3d.a
 
 # Static Library
-$(BUILD_DIR)/t3d.a: $(OBJ)
+$(BUILD_DIR)/libt3d.a: $(OBJ)
 	@mkdir -p $(dir $@)
 	@echo "    [LD_LIB] $<"
-	$(N64_LD) -r -o $(BUILD_DIR)/t3d.a $^
+	$(N64_LD) -r -o $(BUILD_DIR)/libt3d.a $^
 
 $(BUILD_DIR)/rsp/rsp_tiny3d.o: $(SOURCE_DIR)/rsp/rspq_triangle.inc
 $(BUILD_DIR)/rsp/rsp_tiny3d_clipping.o: $(SOURCE_DIR)/rsp/rspq_triangle.inc
@@ -67,6 +69,14 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c
 	@mkdir -p $(dir $@)
 	@echo "    [CC_LIB] $<"
 	$(N64_CC) -c $(CFLAGS) $(N64_CFLAGS) -o $@ $<
+
+install: all
+	mkdir -p $(N64_INST)/mips64-elf/include/t3d
+	install -cv -m 0644 t3d-inst.mk $(N64_INST)/include/t3d.mk
+	for file in $(inc); do \
+		install -Cv -m 0644 $$file $(N64_INST)/mips64-elf/include/t3d; \
+	done
+	install -Cv -m 0644 $(BUILD_DIR)/libt3d.a $(N64_INST)/mips64-elf/lib
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ Checkout the playlist showcasing the example projects in this repo:<br>
 Checkout this repository and build it first (see the Build section), no prebuilts are provided.<br>
 To use Tiny3D in your project, add the following line in your Makefile:
 ```make
-include $(T3D_INST)/t3d.mk
+include $(N64_INST)/include/t3d.mk
 ```
-Where `T3D_INST` points to the path of this repository.<br>
-Internally this will handle adding the correct include path and linking Tiny3D itself into you project.<br>
+Internally this will handle the required configuration to link Tiny3D itself into you project.<br>
+
+If you prefer to keep a local copy of Tiny3D in your project, then just do so (eg: a submodule)
+and include t3d.mk from there:
+```make
+include path/to/t3d.mk
+```
+This will make sure that that specific copy of Tiny3D is used instead.
 
 In general, it's easier to simply take one of the included example projects as a starting point.<br>
 These can be found in the `examples` directory, where each of them goes into details about different features.<br>

--- a/build.sh
+++ b/build.sh
@@ -30,10 +30,12 @@ fi
 # Build Tiny3D
 echo "Building Tiny3D..."
 make -j4
+make install || sudo -E make install
 
 # Tools
 echo "Building tools..."
 make -C tools/gltf_importer -j4
+make -C tools/gltf_importer install || sudo -E make -C tools/gltf_importer install
 
 # Build Examples
 echo "Building examples..."

--- a/t3d-inst.mk
+++ b/t3d-inst.mk
@@ -1,0 +1,2 @@
+N64_LDFLAGS += -lt3d
+T3D_GLTF_TO_3D = $(N64_INST)/bin/gltf_to_t3d

--- a/t3d.mk
+++ b/t3d.mk
@@ -1,4 +1,6 @@
-N64_LDFLAGS := $(T3D_INST)/build/t3d.a $(N64_LDFLAGS)
-N64_C_AND_CXX_FLAGS += -I$(T3D_INST)/src
+T3D_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-T3D_GLTF_TO_3D = $(T3D_INST)/tools/gltf_importer/gltf_to_t3d
+N64_LDFLAGS := $(T3D_DIR)/build/libt3d.a $(N64_LDFLAGS)
+N64_C_AND_CXX_FLAGS += -I$(T3D_DIR)/src
+
+T3D_GLTF_TO_3D := $(T3D_DIR)/tools/gltf_importer/gltf_to_t3d

--- a/tools/gltf_importer/Makefile
+++ b/tools/gltf_importer/Makefile
@@ -27,5 +27,8 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.cpp
 gltf_to_t3d: $(OBJ)
 	$(CXX) $(CXXFLAGS) -o $@ $^ $ $(LINKFLAGS)
 
+install:
+	install -Cv -m 0755 gltf_to_t3d $(N64_INST)/bin/
+
 clean:
 	rm -rf ./build ./gltf_to_t3d


### PR DESCRIPTION
This patch adds support for installation of Tiny3D into `$N64_INST`. 

The main benefit of this is that it simplifies usage of Tiny3D in different projects as there is no more a `$T3D_INST` variable to set in the environment.

This PR creates a new file `t3d-inst.mk`, a variant that is installed as `$N64_INST/include/t3d.mk`. This file is extremely minimal: it just adds `-lt3d` to `LDFLAGS` and define a macro for the `$N64_INST/bin/gltf_to_t3d` tool. I'm honestly not even sure if this would be required anymore. We could simply part with the concept of a `t3d.mk` and let user Makefiles just add `N64_LDFLAGS += -lt3d` to link with Tiny3D.

For instance, this is the diff currently required fo a sample to build with the installed version of Tiny3D:

```diff
diff --git a/examples/12_uv_gen/Makefile b/examples/12_uv_gen/Makefile
index e60fd8d..f23f02f 100644
--- a/examples/12_uv_gen/Makefile
+++ b/examples/12_uv_gen/Makefile
@@ -2,7 +2,7 @@ BUILD_DIR=build
 T3D_INST=$(shell realpath ../..)

 include $(N64_INST)/include/n64.mk
-include $(T3D_INST)/t3d.mk
+include $(N64_INST)/include/t3d.mk

 N64_CFLAGS += -std=gnu2x -Os
```

Is the above much better than the following?

```patch
diff --git a/examples/12_uv_gen/Makefile b/examples/12_uv_gen/Makefile
index e60fd8d..bf2ad11 100644
--- a/examples/12_uv_gen/Makefile
+++ b/examples/12_uv_gen/Makefile
@@ -1,10 +1,9 @@
 BUILD_DIR=build
-T3D_INST=$(shell realpath ../..)

 include $(N64_INST)/include/n64.mk
-include $(T3D_INST)/t3d.mk

 N64_CFLAGS += -std=gnu2x -Os
+N64_LDFLAGS += -lt3d

 PROJECT_NAME=t3d_12_uv_gen

@@ -25,7 +24,7 @@ filesystem/%.sprite: assets/%.png
 filesystem/%.t3dm: assets/%.glb
        @mkdir -p $(dir $@)
        @echo "    [T3D-MODEL] $@"
-       $(T3D_GLTF_TO_3D) "$<" $@
+       $(N64_BINDIR)/gltf_to_t3d "$<" $@
        $(N64_BINDIR)/mkasset -c 2 -o filesystem $@

 $(BUILD_DIR)/$(PROJECT_NAME).dfs: $(assets_conv)
```

Obviously `t3d.mk` keeps the door open in case other changes are necessary. Not sure which would be, though.