### PR TITLE
Add support for installation directory override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 BUILD_DIR=build
 SOURCE_DIR=src/t3d
 
+INSTALLDIR=$(N64_INST)
+
 include $(N64_INST)/include/n64.mk
 
 src := $(SOURCE_DIR)/t3d.c $(SOURCE_DIR)/t3dmath.c $(SOURCE_DIR)/t3dmodel.c \
@@ -71,12 +73,12 @@ $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c
 	$(N64_CC) -c $(CFLAGS) $(N64_CFLAGS) -o $@ $<
 
 install: all
-	mkdir -p $(N64_INST)/mips64-elf/include/t3d
-	install -cv -m 0644 t3d-inst.mk $(N64_INST)/include/t3d.mk
+	mkdir -p $(INSTALLDIR)/mips64-elf/include/t3d
+	install -cv -m 0644 t3d-inst.mk $(INSTALLDIR)/include/t3d.mk
 	for file in $(inc); do \
-		install -Cv -m 0644 $$file $(N64_INST)/mips64-elf/include/t3d; \
+		install -Cv -m 0644 $$file $(INSTALLDIR)/mips64-elf/include/t3d; \
 	done
-	install -Cv -m 0644 $(BUILD_DIR)/libt3d.a $(N64_INST)/mips64-elf/lib
+	install -Cv -m 0644 $(BUILD_DIR)/libt3d.a $(INSTALLDIR)/mips64-elf/lib
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/tools/gltf_importer/Makefile
+++ b/tools/gltf_importer/Makefile
@@ -1,6 +1,7 @@
 CXXFLAGS += -O3 -std=c++20 -I./src/lib
 OBJDIR = build
 SRCDIR = src
+INSTALLDIR = $(N64_INST)
 
 OBJ = build/parser.o build/main.o build/lib/lodepng.o \
 	build/parser/materialParser.o build/parser/boneParser.o build/parser/nodeParser.o \
@@ -28,7 +29,8 @@ gltf_to_t3d: $(OBJ)
 	$(CXX) $(CXXFLAGS) -o $@ $^ $ $(LINKFLAGS)
 
 install:
-	install -Cv -m 0755 gltf_to_t3d $(N64_INST)/bin/
+	mkdir -p $(INSTALLDIR)/bin
+	install -Cv -m 0755 gltf_to_t3d $(INSTALLDIR)/bin/
 
 clean:
 	rm -rf ./build ./gltf_to_t3d


### PR DESCRIPTION
- INSTALLDIR can be set to override directory
- Default directory is still N64_INST

Useful for package building.