### PR TITLE
Clamp color value

### DIFF
--- a/tools/gltf_importer/src/parser.cpp
+++ b/tools/gltf_importer/src/parser.cpp
@@ -227,6 +227,13 @@ T3DMData parseGLTF(const char *gltfPath, float modelScale)
               for(int c=0; c<3; ++c) {
                 v.color[c] = powf(v.color[c], 0.4545f);
               }
+              for (size_t i = 0; i < 4; i++)
+              {
+                if ((v.color[i] - 1.0f) > 0.00001f)
+                {
+                  v.color[i] = 1.f;
+                }
+              }
             }
           }
         }

--- a/tools/gltf_importer/src/parser/materialParser.cpp
+++ b/tools/gltf_importer/src/parser/materialParser.cpp
@@ -165,10 +165,14 @@ namespace {
       colorFloat[c] = powf(colorFloat[c], 0.4545f);
     }
 
-    out[0] = (uint8_t)(colorFloat[0] * 255.0f);
-    out[1] = (uint8_t)(colorFloat[1] * 255.0f);
-    out[2] = (uint8_t)(colorFloat[2] * 255.0f);
-    out[3] = (uint8_t)(colorFloat[3] * 255.0f);
+    for (size_t i = 0; i < 4; i++)
+    {
+      if (colorFloat[i] > 1.f)
+      {
+        colorFloat[i] = 1.f;
+      }
+      out[i] = (uint8_t)(colorFloat[i] * 255.0f);
+    }
   }
 }
 


### PR DESCRIPTION
I'm not sure I agree with this, but blender can allow for colors in the color wheel to have values above 1.f. Tiny3d just treats the value as a percentage of 255.f which seems pretty reasonable. This PR just clamps the value below 1.f