### PR TITLE
new: add t3d.version file to embed in libdragon ROMs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 # These are all bash scripts and should use lf
 *.sh text eol=lf
+t3d.version export-subst

--- a/t3d.version
+++ b/t3d.version
@@ -1,0 +1,5 @@
+{
+  "t3d-hash": "$Format:%H$",
+  "t3d-commit-date": "$Format:%cs$",
+  "t3d-dirty": false
+}


### PR DESCRIPTION
This feature leverages @rasky's recent work on libdragon's preview branch towards embedding toolchain and libdragon version information into ROMs. 

This change (shamelessly) lifts the supporting `Makefile` logic and comments from libdragon, and generates a `t3d.version` file that will be picked up by [N64_TOOLFILES](https://github.com/DragonMinded/libdragon/blob/f3cf179cc3e1f24aeef315b2a1c5d52af265978c/n64.mk#L91) in `n64.mk`. 

Tested by regenerating `99_testscene` (see new `t3d-*` lines):
```
strings t3d_99_testscene.z64 | tail -n 11                  
  "branch": "preview",
  "hash": "06bf1cb00d384f93d5d61fca386ecc5a96ed391e",
  "commit-date": "2025-11-09",                   
  "dirty": true
  "t3d-hash": "db87c29baa6d8688c12fd51f18e84da0455059f3",
  "t3d-commit-date": "2025-11-10",               
  "t3d-dirty": false
  "host": "x86_64-pc-linux-gnu",                 
  "binutils": "2.44",
  "gcc": "14.2.0",
  "newlib": "4.4.0.20231231"               
```
I mostly made this for selfish reasons, to confirm my understand of the mechanisms involved. So feel free to close or delay work on this if it's premature. Thanks for reading!