### PR TITLE
fix anims interpolating from 0 instead of valid initial data

### DIFF
--- a/src/t3d/t3danim.c
+++ b/src/t3d/t3danim.c
@@ -45,6 +45,7 @@ static void rewind_anim(T3DAnim *anim)
   rewind(anim->file);
 }
 
+static inline bool load_keyframe(T3DAnim *anim);
 void t3d_anim_attach(T3DAnim *anim, const T3DSkeleton *skeleton) {
   if(anim->targetsQuat)free(anim->targetsQuat);
 
@@ -79,6 +80,25 @@ void t3d_anim_attach(T3DAnim *anim, const T3DSkeleton *skeleton) {
       default: {assertf(false, "Unknown animation target %d", channelMap->targetType);}
     }
   }
+  
+  uint32_t initCount = 0;
+  while(initCount < channelCount) {
+    if(!load_keyframe(anim)) break;
+    initCount = 0;
+    for(int c = 0; c < anim->animRef->channelsQuat; c++) {
+      if(anim->targetsQuat[c].base.timeEnd > 0) initCount++;
+    }
+    for(int c = 0; c < anim->animRef->channelsScalar; c++) {
+      if(anim->targetsScalar[c].base.timeEnd > 0) initCount++;
+    }
+  }
+  for(int c = 0; c < anim->animRef->channelsQuat; c++) {
+    anim->targetsQuat[c].kfCurr = anim->targetsQuat[c].kfNext;
+  }
+  for(int c = 0; c < anim->animRef->channelsScalar; c++) {
+    anim->targetsScalar[c].kfCurr = anim->targetsScalar[c].kfNext;
+  }
+  rewind_anim(anim);
 }
 
 inline static void attach_scalar(T3DAnim* anim, uint32_t targetIdx, T3DVec3* target, int32_t *updateFlag, uint8_t targetType) {


### PR DESCRIPTION
kfCurr and kfNext are zero from calloc(line 53|54). Without priming them, the first t3d_anim_update() interpolates from zero toward the first keyframe value, causing bones to blend in from the origin. 

This will read the first keyframe for every channel so kfNext holds real data, then mirror it into kfCurr so both ends of the interpolation start at the actual first-frame pose. rewind_anim() resets timeEnd and the file position without touching kfCurr/kfNext, leaving the animation ready for normal playback at t=0.

Before:
<img width="169" height="162" alt="image" src="https://github.com/user-attachments/assets/e4e33fb6-1edf-4e76-8385-1139c03286d7" />


After:
<img width="262" height="219" alt="image" src="https://github.com/user-attachments/assets/3f8ec89b-e01d-45a5-8c5f-2935f54a40ec" />
