### PR TITLE
fix: multiply blend mode for cutout materials

### DIFF
--- a/tools/gltf_importer/src/fast64Types.h
+++ b/tools/gltf_importer/src/fast64Types.h
@@ -13,7 +13,7 @@ namespace {
     RDP::BLEND::NONE, // Opaque
     RDP::BLEND::NONE, // Opaque Decal
     RDP::BLEND::NONE, // Opaque Intersecting
-    RDP::BLEND::NONE, // Cutout
+    RDP::BLEND::MULTIPLY, // Cutout
     RDP::BLEND::MULTIPLY, // Transparent
     RDP::BLEND::MULTIPLY, // Transparent Decal
     RDP::BLEND::MULTIPLY, // Transparent Intersecting
@@ -36,7 +36,7 @@ namespace {
     RDP::BLEND::NONE, // Opaque
     RDP::BLEND::NONE, // Opaque Decal
     RDP::BLEND::NONE, // Opaque Intersecting
-    RDP::BLEND::NONE, // Cutout
+    RDP::BLEND::MULTIPLY, // Cutout
     RDP::BLEND::MULTIPLY, // Transparent
     RDP::BLEND::MULTIPLY, // Transparent Decal
     RDP::BLEND::MULTIPLY, // Transparent Intersecting


### PR DESCRIPTION
Cutout materials exported as gltf from Blender Fast64 (check the 05_splitscreen example) appear fully opaque. Set the imported material blend mode to MULTIPLY to fix this.